### PR TITLE
Fixing addProduct Alert box

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -44,7 +44,10 @@ export default new Vuex.Store({
         product.quantity = payload[0].quantity
         }
       }
-    }
+    },
+    clearSuccess(state) {
+      state.success = null
+  }
   },
   actions: {
     addNewProduct({ commit }, payload) {
@@ -89,7 +92,10 @@ export default new Vuex.Store({
     addAllProducts( {commit }, payload)
     {
       commit('setAllProducts',payload)
-    }
+    },
+    clearSuccess  ( {commit}) {
+      commit('clearSuccess')
+  }
   },
   getters:{
     success (state) {

--- a/src/views/AddProduct.vue
+++ b/src/views/AddProduct.vue
@@ -119,6 +119,7 @@ export default {
   },
 
   mounted: function() {
+    this.$store.dispatch('clearSuccess')
     const productId = this.$route.params.id;
     this.getAllProducts();
     const currentRoute = this.$router.currentRoute.fullPath.split("/")[1];


### PR DESCRIPTION
After adding a new Product , an alert box is shown, If we move to back to some screen and come back to Add Product again the success message is shown, hence clearing the success before mounting to AddProduct